### PR TITLE
Linter tests for all the systems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,12 @@ name: Build and Test
 
 on:
   push:
+    branches:
+      - "G*"
+      - "Carlos/GithubActions"
+
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, "G*"]
     types: [opened, synchronize, reopened, closed]
   workflow_dispatch:
   create:
@@ -67,6 +71,16 @@ jobs:
         with:
           node-version: "18.17.1"
 
+      - name: Cache Node modules and Yarn cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            ~/.yarn
+          key: ${{ runner.OS }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-yarn-
+
       - name: Install dependencies
         run: yarn install
 
@@ -117,7 +131,7 @@ jobs:
   linter_test:
     name: ANDROID LINTER TEST
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'android/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/G')
+    if: contains(github.ref, 'android/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
 
     steps:
       - name: Checkout
@@ -158,7 +172,7 @@ jobs:
 
     # Pipeline to continue Android Test Report Step
     continue-on-error: true
-    if: contains(github.ref, 'android/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/G')
+    if: contains(github.ref, 'android/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
 
     steps:
       - name: Checkout
@@ -190,7 +204,6 @@ jobs:
 
       - name: Unit tests
         working-directory: Android/GreenCircle
-        # Juni test: ./gradlew testDebugUnitTest
         run: ./gradlew testDebugUnitTest --continue
 
       - name: Make unit test report
@@ -209,7 +222,7 @@ jobs:
     name: ANDROID APK GENERATE
     runs-on: ubuntu-latest
     continue-on-error: true
-    if: contains(github.ref, 'android/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/G')
+    if: contains(github.ref, 'android/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
 
     steps:
       - name: Checkout
@@ -256,7 +269,7 @@ jobs:
   backend_linter_test:
     name: BACKEND LINTER TEST
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'backend/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/G')
+    if: contains(github.ref, 'backend/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
 
     steps:
       - name: Checkout
@@ -271,6 +284,16 @@ jobs:
         working-directory: backend
         run: yarn install
 
+      - name: Cache Node modules and Yarn cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            ~/.yarn
+          key: ${{ runner.OS }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-yarn-
+
       - name: Run ESLint
         working-directory: backend
         run: yarn eslint --config .eslintrc.json .
@@ -279,7 +302,7 @@ jobs:
   node_test:
     name: BACKEND UNIT TESTS
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'backend/')  || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/G')
+    if: contains(github.ref, 'backend/')  || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
 
     steps:
       - name: Checkout
@@ -289,6 +312,16 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "18.17.1"
+
+      - name: Cache Node modules and Yarn cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            ~/.yarn
+          key: ${{ runner.OS }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-yarn-
 
       - name: Install dependencies
         working-directory: backend
@@ -313,7 +346,7 @@ jobs:
   admin_linter_test:
     name: ADMIN PANEL LINTER TEST
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'Admin/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/G')
+    if: contains(github.ref, 'Admin/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
 
     steps:
       - name: Checkout
@@ -323,6 +356,16 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "18.17.1"
+
+      - name: Cache Node modules and Yarn cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            ~/.yarn
+          key: ${{ runner.OS }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-yarn-
 
       - name: Install dependencies
         working-directory: Admin
@@ -336,7 +379,7 @@ jobs:
   node_test_admin:
     name: ADMIN PANEL UNIT TESTS
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'Admin/')  || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/G')
+    if: contains(github.ref, 'Admin/')  || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
 
     steps:
       - name: Checkout
@@ -346,6 +389,16 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "18.17.1"
+
+      - name: Cache Node modules and Yarn cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            ~/.yarn
+          key: ${{ runner.OS }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-yarn-
 
       - name: Install dependencies
         working-directory: Admin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,44 @@ jobs:
         env:
           APPSWEEP_API_KEY: ${{ secrets.APPSWEEP_API_KEY }}
 
+  ## Android Linter test
+  linter_test:
+    name: ANDROID LINTER TEST
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'android/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/G')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Print Java Version
+        run: javac -version
+
+      - name: Change wrapper permissions
+        run: chmod +x ./gradlew
+        working-directory: Android/GreenCircle
+
+      - name: Restore cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Linter test
+        working-directory: Android/GreenCircle
+        run: ./gradlew kttlintCheck
+
   # Android Test
   unit_test:
     name: ANDROID UNIT TEST
@@ -215,6 +253,28 @@ jobs:
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
 
+  backend_linter_test:
+    name: BACKEND LINTER TEST
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'backend/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/G')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.JS
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18.17.1"
+
+      - name: Install dependencies
+        working-directory: backend
+        run: yarn install
+
+      - name: Run ESLint
+        working-directory: backend
+        run: yarn eslint --config .eslintrc.json .
+
   # Backend Testing with JEST
   node_test:
     name: BACKEND UNIT TESTS
@@ -234,7 +294,7 @@ jobs:
         working-directory: backend
         run: yarn install
 
-      - name: Run Jest with Coverage
+      - name: Run Mocha & Chai Test
         working-directory: backend
         run: yarn test
         env:
@@ -248,6 +308,29 @@ jobs:
         with:
           name: mocha-chai-test-report
           path: ./test-results/test-report.xml
+
+  # Admin panel linter test
+  admin_linter_test:
+    name: ADMIN PANEL LINTER TEST
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'Admin/') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/G')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.JS
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18.17.1"
+
+      - name: Install dependencies
+        working-directory: Admin
+        run: yarn install
+
+      - name: Run ESLint
+        working-directory: Admin
+        run: yarn eslint --config .eslintrc.json .
 
   # Admin panel unit testing
   node_test_admin:
@@ -268,7 +351,7 @@ jobs:
         working-directory: Admin
         run: yarn install
 
-      - name: Run Jest with Coverage
+      - name: Run Mocho & Chai Test
         working-directory: Admin
         run: yarn test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
       - "Carlos/GithubActions"
 
   pull_request:
-    branches: [main, develop, "G*"]
+    branches: [main, develop]
     types: [opened, synchronize, reopened, closed]
   workflow_dispatch:
   create:

--- a/Admin/yarn.lock
+++ b/Admin/yarn.lock
@@ -746,11 +746,6 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-charenc@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-  integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
-
 check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -844,11 +839,6 @@ cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypt@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
-  integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -1792,11 +1782,6 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-buffer@~1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
@@ -2153,15 +2138,6 @@ make-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
-md5@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
-  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
-  dependencies:
-    charenc "0.0.2"
-    crypt "0.0.2"
-    is-buffer "~1.1.6"
-
 memoizee@^0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz#e6f3d2da863f318d02225391829a6c5956555b72"
@@ -2228,22 +2204,6 @@ mkdirp@^0.5.1:
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
     minimist "^1.2.6"
-
-mkdirp@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-3.0.1.tgz#e44e4c5607fb279c168241713cc6e0fea9adcb50"
-  integrity sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==
-
-mocha-junit-reporter@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/mocha-junit-reporter/-/mocha-junit-reporter-2.2.1.tgz#739f5595d0f051d07af9d74e32c416e13a41cde5"
-  integrity sha512-iDn2tlKHn8Vh8o4nCzcUVW4q7iXp7cC4EB78N0cDHIobLymyHNwe0XG8HEHHjc3hJlXm0Vy6zcrxaIhnI2fWmw==
-  dependencies:
-    debug "^4.3.4"
-    md5 "^2.3.0"
-    mkdirp "^3.0.0"
-    strip-ansi "^6.0.1"
-    xml "^1.0.1"
 
 mocha@^10.2.0:
   version "10.2.0"
@@ -3392,11 +3352,6 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
-
-xml@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
-  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/backend/src/services/users.service.ts
+++ b/backend/src/services/users.service.ts
@@ -1,5 +1,4 @@
 import User from '../models/users.model'
-import { PaginatedQuery, PaginationParams } from '../utils/RequestResponse'
 
 /**
  * @function getAllUsers


### PR DESCRIPTION
## Changes

- New Linter test for android. Calls the ktlintCheck shells script parameter to check android project. 
- New linter test for backend and admin system. Calls the .eslint.json file in the directory
- NodeJS and yarn caching to speed up jobs
- New rules for pushing on every G*/UserStory branches and GithubActions one

## Branch Protection Rules

Following good practices, all linter tests will run all the time. A passing state is required to merge to develop or main. 