### PR TITLE
Refactor: Network Service

### DIFF
--- a/ios/GreenCircle/GreenCircle/Data/Remote/Network/NetworkAPIService.swift
+++ b/ios/GreenCircle/GreenCircle/Data/Remote/Network/NetworkAPIService.swift
@@ -7,11 +7,13 @@
 import Alamofire
 import Foundation
 
+struct NoResponse: Codable {}
+
 /// Clase con el serivicio de la API
 class NetworkAPIService {
   static let shared = NetworkAPIService()
-  let decoder = JSONDecoder()
-  var session = Session()
+  private let decoder = JSONDecoder()
+  private var session = Session()
   
   init() {
     self.decoder.dateDecodingStrategy = .iso8601WithFractionalSeconds
@@ -21,26 +23,17 @@ class NetworkAPIService {
     self.session = Session(interceptor:
                             AuthRequestAdapter(authToken))
   }
-
-  /// Función encargada de postear al backend la información de un nuevo usuario registrado con Google
-  /// - Parameters:
-  ///   - url: url para hacer el POST
-  ///   - googleToken: token de identidad de Google
-  /// - Returns: respuesta de autenticación con tokens e información del usuario
-  func postGoogleSignIn(url: URL, googleToken: String) async -> AuthResponse? {
-    let params: Parameters = ["googleToken": googleToken]
+  
+  func getRequest<T: Codable>(_ url: URL) async -> T? {
+    let requestTask = session
+      .request(url).validate()
     
-    let requestTask = session.request(url, method: .post,
-                                 parameters: params,
-                                 encoding: JSONEncoding.default)
-      .validate()
     let response = await requestTask.serializingData().response
-
+    
     switch response.result {
     case let .success(data):
       do {
-        return try decoder
-          .decode(AuthResponse.self, from: data)
+        return try decoder.decode(T.self, from: data)
       } catch {
         return nil
       }
@@ -48,86 +41,44 @@ class NetworkAPIService {
       debugPrint(error)
       return nil
     }
-
   }
-
-  /// Actualiza un usuario con la información proporcionada
-  /// - Parameters:
-  ///   - url: el url para realizar el PUT
-  ///   - authToken: token de autenticación
-  ///   - user: la información del usuario a actualizar
-  func putUser(url: URL, user: UserAuth) async {
-    let params: Parameters = [
-      "phoneNumber": user.phone!,
-      "age": user.age!,
-      "gender": user.gender!,
-      "state": user.state!,
-      "roleId": "CUSTOMER_ROLE_ID"
-    ]
-    let requestTask = session.request(url, method: .put,
-                                 parameters: params).validate()
-    let response = await requestTask.serializingData().response
-
-    switch response.result {
-    case .success(_):
-      return
-    case let .failure(error):
-      debugPrint(error)
-    }
-  }
-
-  /// Crea una compañía nueva
-  /// - Parameters:
-  ///   - url: url para hacer el post
-  ///   - authToken: token de autenticación
-  ///   - company: datos de la compañía a postear
-  func postCompany(url: URL, authToken: String, company: PostCompanyData) async {
-    let params: Parameters = [
-      "company": [
-        "name": company.name,
-        "description": company.description,
-        "email": company.email,
-        "phone": company.phone,
-        "webPage": company.webPage,
-        "street": company.street,
-        "streetNumber": company.streetNumber!,
-        "city": company.city,
-        "state": company.state,
-        "zipCode": company.zipCode!,
-        "userId": company.userId!,
-        "pdfCurriculumUrl": company.pdfCurriculumUrl,
-        "pdfGuaranteeSecurityUrl": company.pdfGuaranteeSecurityUrl,
-        "pdfActaConstitutivaUrl": company.pdfActaConstitutivaUrl,
-        "pdfIneUrl": company.pdfIneUrl
-      ] as [String : Any]
-    ]
-
-    let requestTask = session.request(url, method: .post,
-                                 parameters: params).validate()
+  
+  func postRequest<T: Codable>(_ url: URL, body: [String: Any]) async -> T? {
+    let requestTask = session
+      .request(url, method: .post,
+               parameters: body as Parameters,
+               encoding: JSONEncoding.default)
+      .validate()
     
     let response = await requestTask.serializingData().response
+    
     switch response.result {
-    case .success(_):
-      return
+    case let .success(data):
+      do {
+        return try decoder.decode(T.self, from: data)
+      } catch {
+        return nil
+      }
     case let .failure(error):
       debugPrint(error)
+      return nil
     }
   }
-
-  /// - Description: Obtener encuesta pendiente
-  /// - Parameter url: URL
-  /// - Returns: Modelo de encuesta o nil (SurveyModel?)
-  func getPendingSurvey(url: URL) async -> SurveyModel? {
-    let requestTask = session.request(url, method: .get).validate()
+  
+  func putRequest<T: Codable>(_ url: URL, body: [String: Any]) async -> T? {
+    let requestTask = session
+      .request(url, method: .put,
+               parameters: body as Parameters,
+               encoding: JSONEncoding.default)
+      .validate()
+    
     let response = await requestTask.serializingData().response
-
+    
     switch response.result {
-    case .success(let data):
+    case let .success(data):
       do {
-        return try decoder
-          .decode(SurveyModel.self, from: data)
+        return try decoder.decode(T.self, from: data)
       } catch {
-        debugPrint(error)
         return nil
       }
     case let .failure(error):
@@ -135,116 +86,4 @@ class NetworkAPIService {
       return nil
     }
   }
-
-  /// - Description: Enviar respuestas de la encuesta
-  /// - Parameters:
-  ///   - url: URL
-  ///   - answers: Las respuestas de la encuesta
-  /// - Returns: Bool
-  func submitAnswers(url: URL, answers: [Answer]) async -> Bool {
-
-    var processAns = [[String: Any]]()
-
-    answers.forEach{
-      answer in
-      if let answerText = answer.answerText {
-        processAns.append(["questionId": answer.questionId, "answerText": answerText])
-      }
-      if let scaleValue = answer.scaleValue {
-        processAns.append(["questionId": answer.questionId, "scaleValue": scaleValue])
-      }
-    }
-
-    let body: Parameters = ["answers":  processAns]
-    let requestTask = session.request(url, method: .post, parameters: body, encoding: JSONEncoding()).validate()
-    let response = await requestTask.serializingData().response
-
-    switch response.result {
-    case .success:
-      return true
-    case let .failure(error):
-      debugPrint(error)
-      return false
-    }
-  }
-
-  ///  Fetch toda la ecoInfo del  backend
-  ///  - Parameter url: ruta al endpoint
-  ///  - Returns EcoInfo decoded o error
-  func fetchAllEcoInfo(url: URL) async -> [EcoInfo]? {
-    let requestTask = session.request(url, method: .get).validate()
-    let response = await requestTask.serializingData().response
-    switch response.result {
-    case .success(let data):
-      do {
-        return
-          try decoder
-          .decode([EcoInfo].self, from: data)
-      } catch {
-        debugPrint(error)
-        return nil
-      }
-    case let .failure(error):
-      debugPrint(error)
-      return nil
-    }
-  }
-
-  /// Obtener compañía por id
-  ///  - Parameters:
-  ///     - url: Backend url para obtener datos
-  ///  - Returns: Modelo de compañía o error en cualquier otro caso no válido
-  func fetchCompanyById(url: URL) async -> Company? {
-    let taskRequest = session.request(url, method: .get).validate()
-    let response = await taskRequest.serializingData().response
-    switch response.result {
-    case .success(let data):
-      do {
-        return
-          try decoder
-          .decode(Company.self, from: data)
-      } catch {
-        debugPrint(error)
-        return nil
-      }
-    case let .failure(error):
-      debugPrint(error.localizedDescription)
-      return nil
-    }
-  }
-
-  func fetchAllCompanies(url: URL) async -> PaginatedQuery<Company>?{
-    let taskRequest = session.request(url, method: .get).validate()
-    let response = await taskRequest.serializingData().response
-    switch response.result {
-    case .success(let data):
-      do {
-        return
-          try decoder
-          .decode(PaginatedQuery<Company>.self, from: data)
-      } catch {
-        debugPrint(error)
-        return nil
-      }
-    case let .failure(error):
-      debugPrint(error.localizedDescription)
-      return nil
-    }
-  }
-      func getCoordinates(url: URL) async -> PaginatedQuery<Company>? {
-        let taskRequest = AF.request(url, method: .get).validate()
-        let response = await taskRequest.serializingData().response
-        switch response.result {
-        case .success(let data):
-            do {
-                return try JSONDecoder().decode(PaginatedQuery<Company>.self, from: data)
-            } catch {
-                return nil
-            }
-        case let .failure(error):
-            print(error)
-            debugPrint(error.localizedDescription)
-            return nil
-        }
-    }
 }

--- a/ios/GreenCircle/GreenCircle/Data/Repository/CompanyRepository.swift
+++ b/ios/GreenCircle/GreenCircle/Data/Repository/CompanyRepository.swift
@@ -40,7 +40,8 @@ class CompanyRepository: CompanyRepositoryProtocol {
   ///   - Returns: Modelo de compañía
   func fetchCompanyById(companyId: UUID) async -> Company? {
     return await service
-      .fetchCompanyById(url: URL(string: "\(CompanyAPI.base)/\(companyId.uuidString.lowercased())")!)
+      .getRequest(URL(string:
+                        "\(CompanyAPI.base)/\(companyId.uuidString.lowercased())")!)
   }
   
   /// Función que llama al servicio de conexión con la API para postear una  nueva compañía
@@ -48,16 +49,34 @@ class CompanyRepository: CompanyRepositoryProtocol {
   ///   - authToken: token de autenticación
   ///   - company: el objeto con la información de la compañía
   func postCompany(authToken: String, company: PostCompanyData) async {
-    await service
-      .postCompany(url:
-                    URL(
-                      string: "\(CompanyAPI.base)\(CompanyAPI.Routes.create)")!,
-                   authToken: authToken, company: company)
+    let params: [String: Any] = [
+      "company": [
+        "name": company.name,
+        "description": company.description,
+        "email": company.email,
+        "phone": company.phone,
+        "webPage": company.webPage,
+        "street": company.street,
+        "streetNumber": company.streetNumber!,
+        "city": company.city,
+        "state": company.state,
+        "zipCode": company.zipCode!,
+        "userId": company.userId!,
+        "pdfCurriculumUrl": company.pdfCurriculumUrl,
+        "pdfGuaranteeSecurityUrl": company.pdfGuaranteeSecurityUrl,
+        "pdfActaConstitutivaUrl": company.pdfActaConstitutivaUrl,
+        "pdfIneUrl": company.pdfIneUrl
+      ] as [String : Any]
+    ]
+    let _: NoResponse? = await service
+      .postRequest(URL(
+        string: "\(CompanyAPI.base)\(CompanyAPI.Routes.create)")!,
+                   body: params)
   }
   
   func fetchAllCompanies() async -> PaginatedQuery<Company>? {
     return await service
-      .fetchAllCompanies(url: URL(string: "\(CompanyAPI.base)")!)
+      .getRequest(URL(string: "\(CompanyAPI.base)")!)
   }
   
 }

--- a/ios/GreenCircle/GreenCircle/Data/Repository/EcoInfoRepository.swift
+++ b/ios/GreenCircle/GreenCircle/Data/Repository/EcoInfoRepository.swift
@@ -32,7 +32,7 @@ class EcoInfoRepository: EcoInfoApiProtocol {
   func fetchAllEcoInfo() async -> [EcoInfo]? {
     return
       await service
-      .fetchAllEcoInfo(url: URL(string: "\(ApiEcoInfo.base)\(ApiEcoInfo.Routes.ecoInfo)")!)
+      .getRequest(URL(string: "\(ApiEcoInfo.base)\(ApiEcoInfo.Routes.ecoInfo)")!)
   }
 
 }

--- a/ios/GreenCircle/GreenCircle/Data/Repository/GetCoordinatesRepository.swift
+++ b/ios/GreenCircle/GreenCircle/Data/Repository/GetCoordinatesRepository.swift
@@ -34,6 +34,6 @@ class GetCoordinatesRepossitory: GetCoordinatesAPIProtocol {
   ///   - Parameters: UUID de la compañía
   ///   - Returns: Modelo de compañía
   func getCoordinates(companyId: UUID) async -> PaginatedQuery<Company>? {
-    return await service.getCoordinates(url: URL(string: "\(ApiCompany.baseCompany)/\(companyId.uuidString.lowercased())")!)
+    return await service.getRequest(URL(string: "\(ApiCompany.baseCompany)/\(companyId.uuidString.lowercased())")!)
   }
 }

--- a/ios/GreenCircle/GreenCircle/Data/Repository/SurveyRepository.swift
+++ b/ios/GreenCircle/GreenCircle/Data/Repository/SurveyRepository.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Alamofire
 
 class SurveyApi {
   static let base = "http://localhost:4000/api/v1"
@@ -34,8 +33,9 @@ class SurveyRepository: SurveyApiProtocol {
   /// - Returns: Modelo de encuesta o nil (SurveyModel?)
   func getPendingSurvey() async -> SurveyModel? {
     let userId = "abcd-1234-efgh-5678"
-    let surveyRoute = SurveyApi.Routes.survey.replacingOccurrences(of: ":userId", with: userId)
-    return await service.getPendingSurvey(url: URL(string: "\(SurveyApi.base)\(surveyRoute)")!)
+    let url = URL(string: SurveyApi.Routes.survey
+      .replacingOccurrences(of: ":userId", with: userId))!
+    return await service.getRequest(url)
   }
   
   /// - Description: Enviar respuestas de la encuesta
@@ -45,10 +45,31 @@ class SurveyRepository: SurveyApiProtocol {
   /// - Returns: Bool
   func submitAnswers(surveyId: String, answers : [Answer]) async -> Bool {
     let userId = "8de45630-2e76-4d97-98c2-9ec0d1f3a5b8"
-    let surveyRoute = SurveyApi.Routes.submitSurvey.replacingOccurrences(of: ":userId", with: userId)
+    let surveyRoute = SurveyApi.Routes.submitSurvey
+      .replacingOccurrences(of: ":userId", with: userId)
       .replacingOccurrences(of: ":surveyId", with: surveyId)
     
-    return await service.submitAnswers(url: URL(string: "\(SurveyApi.base)\(surveyRoute)")!, answers: answers)
+    var processAns = [[String: Any]]()
+    
+    answers.forEach{
+      answer in
+      if let answerText = answer.answerText {
+        processAns.append(["questionId": answer.questionId, "answerText": answerText])
+      }
+      if let scaleValue = answer.scaleValue {
+        processAns.append(["questionId": answer.questionId, "scaleValue": scaleValue])
+      }
+    }
+    
+    let body: [String: Any] = ["answers":  processAns]
+    
+    let res: NoResponse? = await service.postRequest(URL(string: "\(SurveyApi.base)\(surveyRoute)")!, body: body)
+    
+    if res != nil {
+      return true
+    } else {
+      return false
+    }
   }
   
 }

--- a/ios/GreenCircle/GreenCircle/Data/Repository/UserRepository.swift
+++ b/ios/GreenCircle/GreenCircle/Data/Repository/UserRepository.swift
@@ -17,10 +17,9 @@ class AuthAPI {
 
 /// Clase con la estructura de la API de usuarios
 class UserAPI {
-  static let base = "http://localhost:4000/api/v1"
+  static let base = "http://localhost:4000/api/v1/users"
   struct Routes {
     static let userId = "/:userId"
-    static let user = "users"
     static let credentials = "users/credentials"
   }
 }
@@ -65,10 +64,11 @@ class UserRepository: UserRepositoryProtocol {
   /// - Parameter googleToken: token proporcionado por Google
   /// - Returns: Una respuesta de autenticación, con Tokens e información del usuario
   func postGoogleLogin(googleToken: String) async -> AuthResponse? {
+    let params: [String: Any] = ["googleToken": googleToken]
     return await nService
-      .postGoogleSignIn(url: URL(
+      .postRequest(URL(
         string: "\(AuthAPI.base)\(AuthAPI.Routes.googleLogin)")!,
-                        googleToken: googleToken)
+                   body: params)
   }
   
   /// Actualiza la información de un usuario
@@ -76,22 +76,29 @@ class UserRepository: UserRepositoryProtocol {
   ///   - authToken: token de autenticación
   ///   - user: información del usuario a actualizar
   func putUser(authToken: String, user: UserAuth) async {
+    let params: [String: Any] = [
+      "phoneNumber": user.phone!,
+      "age": user.age!,
+      "gender": user.gender!,
+      "state": user.state!,
+      "roleId": "CUSTOMER_ROLE_ID"
+    ]
+    
     let url = URL(
       string: "\(UserAPI.base)\(UserAPI.Routes.userId)"
         .replacingOccurrences(
-          of: ":id",
+          of: ":userId",
           with: user.id))!
-    await nService.putUser(url: url,
-                           authToken: authToken,
-                           user: user)
+    
+    let _: NoResponse? = await nService.putRequest(url, body: params)
   }
   
   func fetchUserById(userId: String) async -> User? {
-    return await backEndService.fetchUserById(url: URL(string: "\(UserAPI.base)/\(UserAPI.Routes.user)/\(userId)")!)
+    return await backEndService.fetchUserById(url: URL(string: "\(UserAPI.base)/\(userId)")!)
   }
   
   func updateUserData(updatedUserData: User, userId: String) async -> User? {
-    return await backEndService.UpdateUserData(url: URL(string: "\(UserAPI.base)/\(UserAPI.Routes.user)/\(userId)")!, updatedUserData: updatedUserData)
+    return await backEndService.UpdateUserData(url: URL(string: "\(UserAPI.base)/\(userId)")!, updatedUserData: updatedUserData)
   }
   
   func updateUserCredentials(userId: String, newUserCredentials: Credentials) async -> User? {

--- a/ios/GreenCircle/GreenCircle/Domain/Models/SurveyModel.swift
+++ b/ios/GreenCircle/GreenCircle/Domain/Models/SurveyModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct SurveyModel: Decodable, Identifiable {
+struct SurveyModel: Codable, Identifiable {
   let surveyId: String
   let title: String
   let description: String
@@ -18,7 +18,7 @@ struct SurveyModel: Decodable, Identifiable {
   }
 }
 
-struct SurveyQuestion: Decodable, Identifiable, Hashable {
+struct SurveyQuestion: Codable, Identifiable, Hashable {
   var questionId: String
   let questionOptions: [QuestionOption]
   let questionText: String
@@ -29,14 +29,14 @@ struct SurveyQuestion: Decodable, Identifiable, Hashable {
     return questionId
   }
   
-  enum QuestionType: String, Decodable, Hashable {
+  enum QuestionType: String, Codable, Hashable {
     case open = "open"
     case scale = "scale"
     case multiple_choice = "multiple_choice"
   }
 }
 
-struct QuestionOption: Decodable, Identifiable, Hashable {
+struct QuestionOption: Codable, Identifiable, Hashable {
   let questionOptionId: String
   let textOption: String
   


### PR DESCRIPTION
# Refactor del Network Service
- Ahora hay requests genéricas, de tal manera que el service solo hace HTTP requests, mientras que el repository se encarga de la lógica del body.
- Readaptación de todas las requests en develop

De esta manera, segmentamos la funcionalidad usando los repositorios, y mantenemos limpio el archivo del **Network Service**