### PR TITLE
feat(Survey): Survey now takes userId from sharedPreferences

### DIFF
--- a/Android/GreenCircle/app/src/main/java/com/greencircle/data/repository/SurveyRepository.kt
+++ b/Android/GreenCircle/app/src/main/java/com/greencircle/data/repository/SurveyRepository.kt
@@ -7,15 +7,15 @@ import java.util.UUID
 
 class SurveyRepository {
     private var apiSurvey = SurveyAPIClient()
-    suspend fun getSurveyPending(): Survey? {
+    suspend fun getSurveyPending(userId: UUID): Survey? {
         return apiSurvey
-            .getSurveyPending(UUID.fromString("8de45630-2e76-4d97-98c2-9ec0d1f3a5b8"))
+            .getSurveyPending(userId)
     }
 
-    suspend fun submitAnswers(surveyId: UUID, answers: List<Answer>) {
+    suspend fun submitAnswers(surveyId: UUID, userId: UUID, answers: List<Answer>) {
         // send answers to server
         apiSurvey.submitAnswers(
-            UUID.fromString("8de45630-2e76-4d97-98c2-9ec0d1f3a5b8"),
+            userId,
             surveyId,
             answers,
         )

--- a/Android/GreenCircle/app/src/main/java/com/greencircle/domain/usecase/survey/SurveyRequirement.kt
+++ b/Android/GreenCircle/app/src/main/java/com/greencircle/domain/usecase/survey/SurveyRequirement.kt
@@ -9,12 +9,12 @@ import java.util.UUID
 class SurveyRequirement {
     private val repository = SurveyRepository()
 
-    suspend fun getSurveyPending(): Survey? =
-        repository.getSurveyPending()
+    suspend fun getSurveyPending(userId: UUID): Survey? =
+        repository.getSurveyPending(userId)
 
-    suspend fun submitAnswers(surveyId: UUID, answers: List<Answer>) {
+    suspend fun submitAnswers(surveyId: UUID, userId: UUID, answers: List<Answer>) {
         try {
-            repository.submitAnswers(surveyId, answers)
+            repository.submitAnswers(surveyId, userId, answers)
         } catch (e: Exception) {
             Log.i("Salida", e.toString())
         }

--- a/Android/GreenCircle/app/src/main/java/com/greencircle/framework/viewmodel/survey/SurveyViewModel.kt
+++ b/Android/GreenCircle/app/src/main/java/com/greencircle/framework/viewmodel/survey/SurveyViewModel.kt
@@ -21,9 +21,9 @@ class SurveyViewModel : ViewModel() {
     val surveyLiveData = MutableLiveData<Survey?>()
     val submitStatusLiveData = MutableLiveData<SubmitStatus>()
     val surveyPendingRequirement = SurveyRequirement()
-    fun getSurveyPending() {
+    fun getSurveyPending(userId: UUID) {
         viewModelScope.launch(Dispatchers.IO) {
-            val data = surveyPendingRequirement.getSurveyPending()
+            val data = surveyPendingRequirement.getSurveyPending(userId)
             Log.d("Salida", data?.toString() ?: "null")
             CoroutineScope(Dispatchers.Main).launch {
                 surveyLiveData.postValue(data)
@@ -31,7 +31,7 @@ class SurveyViewModel : ViewModel() {
         }
     }
 
-    fun submitAnswers() {
+    fun submitAnswers(userId: UUID) {
         try {
             val survey = surveyLiveData.value
             if (survey == null) {
@@ -51,7 +51,7 @@ class SurveyViewModel : ViewModel() {
 
             Log.i("Salida", answers.toString())
             viewModelScope.launch(Dispatchers.IO) {
-                surveyPendingRequirement.submitAnswers(survey.surveyId, answers)
+                surveyPendingRequirement.submitAnswers(survey.surveyId, userId, answers)
                 CoroutineScope(Dispatchers.Main).launch {
                     submitStatusLiveData.postValue(SubmitStatus.success)
                 }

--- a/Android/GreenCircle/app/src/main/java/com/greencircle/framework/views/activities/SurveyActivity.kt
+++ b/Android/GreenCircle/app/src/main/java/com/greencircle/framework/views/activities/SurveyActivity.kt
@@ -12,16 +12,25 @@ import com.greencircle.domain.model.survey.Question
 import com.greencircle.framework.viewmodel.survey.SurveyViewModel
 import com.greencircle.framework.views.fragments.survey.QuestionFragment
 import java.util.UUID
+import org.json.JSONObject
 
 class SurveyActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySurveyBinding
     private val viewModel: SurveyViewModel by viewModels()
     private val fragmentManager = supportFragmentManager
+    lateinit var userId: UUID
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initializeBinding()
         initializeObservers()
-        viewModel.getSurveyPending()
+
+        val sharedPreferences = getSharedPreferences("my_preferences", MODE_PRIVATE)
+        val userJson = sharedPreferences?.getString("user_session", null)
+        val userJSON = JSONObject(userJson!!)
+        Log.d("SalidaUserJson", userJSON.getString("uuid"))
+        userId = UUID.fromString(userJSON.getString("uuid"))
+
+        viewModel.getSurveyPending(userId)
     }
 
     private fun initializeObservers() {
@@ -43,19 +52,16 @@ class SurveyActivity : AppCompatActivity() {
                 }
 
                 SurveyViewModel.SubmitStatus.validationError -> {
-                    MaterialAlertDialogBuilder(this)
-                        .setTitle("Faltan preguntas")
-                        .setMessage(
-                            "No puedes enviar sin antes haber " +
-                                "termiandode llenar todas las preguntas obligatorias.",
-                        ).setCancelable(false).setPositiveButton("Seguir") { _, _ -> }.show()
+                    MaterialAlertDialogBuilder(this).setTitle("Faltan preguntas").setMessage(
+                        "No puedes enviar sin antes haber " +
+                            "termiandode llenar todas las preguntas obligatorias.",
+                    ).setCancelable(false).setPositiveButton("Seguir") { _, _ -> }.show()
                 }
 
                 SurveyViewModel.SubmitStatus.error -> {
                     MaterialAlertDialogBuilder(this).setTitle("Error")
                         .setMessage("No se pudieron enviar tus respuestas. Inténtalo más tarde.")
-                        .setCancelable(false)
-                        .setPositiveButton("Aceptar") { _, _ -> goToMain() }
+                        .setCancelable(false).setPositiveButton("Aceptar") { _, _ -> goToMain() }
                         .show()
                 }
             }
@@ -66,7 +72,7 @@ class SurveyActivity : AppCompatActivity() {
         binding = ActivitySurveyBinding.inflate(layoutInflater)
         binding.BtnSubmit.setOnClickListener {
             Log.i("Salida", viewModel.surveyLiveData.value.toString())
-            viewModel.submitAnswers()
+            viewModel.submitAnswers(userId)
         }
         binding.topAppBar.setOnClickListener {
             MaterialAlertDialogBuilder(this).setTitle("¿Quieres dejar de responder?")


### PR DESCRIPTION
# User Story

| US ID | Module | User Story                                                                  | System  | Priority | Size | Testing | Documentation |
| ----- | ------ | --------------------------------------------------------------------------- | ------- | -------- | ---- | ------- | ------------- |
| 334   | ENCUESTA   | Enviar el user id de shared preferences | Android | High     | 2    | Done    | Done          |

### Description

Yo como desarrollador quiero que el id de las encuestas se consiga de shared preferences, para garantizar que no haya valores hardcodeados y un buen funcionamiento

### Acceptance Criteria

- [x]  El Id para solicitar encuestas pendientes viene de shared preferences
- [x]  El Id para registrar respuesta viene de shared preferences
- [x]  Se eliminan todos los valores de id hardcodeados de encuestas
