### PR TITLE
fix(PerfilCliente): Arreglar field de nombre y botón de guardar

### DIFF
--- a/ios/GreenCircle/GreenCircle/Presentation/Views/Profile/EditProfileView.swift
+++ b/ios/GreenCircle/GreenCircle/Presentation/Views/Profile/EditProfileView.swift
@@ -278,6 +278,7 @@ struct Section2: View {
                   options: GENDERS
               )
               .padding(.top, 5)
+              .foregroundColor(Color("Secondary"))
             }
         }
     }
@@ -392,6 +393,7 @@ struct Section3: View {
             options: Constants.states
         )
         .padding(.top, 5)
+        .foregroundColor(Color("Secondary"))
       }
 
     }

--- a/ios/GreenCircle/GreenCircle/Presentation/Views/Profile/EditProfileView.swift
+++ b/ios/GreenCircle/GreenCircle/Presentation/Views/Profile/EditProfileView.swift
@@ -59,7 +59,6 @@ struct SectionProfile: View{
   }
 }
 
-
 ///_----------------- SECTION 1_
 struct Section1: View{
   @ObservedObject var modelUser = UserViewModel()
@@ -70,8 +69,8 @@ struct Section1: View{
               get: { self.modelUser.contentBaseUser?.firstName ?? "" },
               set: { newValue in
                   if !containsNumber(input: newValue) {
-                    if var contentUser = self.modelUser.contentBaseUser {
-                      contentUser.firstName = newValue
+                      if self.modelUser.contentBaseUser != nil {
+                          self.modelUser.contentBaseUser?.firstName = newValue
                       }
                   }
               }
@@ -202,6 +201,7 @@ struct Section2: View {
           }
       )
   }
+
   
   func isBlank(input: String) -> Bool {
       return input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -278,7 +278,6 @@ struct Section2: View {
                   options: GENDERS
               )
               .padding(.top, 5)
-              .foregroundColor(Color("Secondary"))
             }
         }
     }
@@ -323,12 +322,13 @@ struct Section3: View {
       return input.range(of: "^[0-9]+$",
                          options: .regularExpression) != nil
   }
-    
+  
   func isPhoneNumberValid() -> Bool {
-      guard let phoneNumber = modelUser.contentBaseUser?.phoneNumber 
+      guard let phoneNumber = modelUser.contentBaseUser?.phoneNumber
     else { return false }
-      return phoneNumber.count == 10
+      return phoneNumber.count == 12
   }
+
   
   var body: some View {
       VStack(alignment: .leading) {
@@ -339,23 +339,23 @@ struct Section3: View {
               .font(.system(size: 13))
               .fontWeight(.semibold)
 
-          TextField("Teléfono", text: Binding(
-              get: {
-                  if let phoneNumber = self.modelUser.contentBaseUser?.phoneNumber, !phoneNumber.isEmpty {
-                    return Utils
-                      .formatNumber(with: "XXX-XXX-XXXX",
-                                    for: phoneNumber)
-                  } else {
-                      return ""
-                  }
-              },
-              set: {
-                self.modelUser.contentBaseUser?
-                  .phoneNumber =
-                Utils.formatNumber(with: "XXX-XXX-XXXX",
-                                   for: $0)
-              }
-          ))
+        TextField("Teléfono", text: Binding(
+            get: {
+                if let phoneNumber = self.modelUser.contentBaseUser?.phoneNumber, !phoneNumber.isEmpty {
+                  return Utils
+                    .formatNumber(with: "XXX-XXX-XXXX",
+                                  for: phoneNumber)
+                } else {
+                    return ""
+                }
+            },
+            set: {
+              self.modelUser.contentBaseUser?
+                .phoneNumber =
+              Utils.formatNumber(with: "XXX-XXX-XXXX",
+                                 for: $0)
+            }
+        ))
           .keyboardType(.numberPad)
           .padding(.top, 3)
           .font(.system(size: 13))
@@ -366,14 +366,8 @@ struct Section3: View {
             Text("No puedes dejar este campo vacío.")
                 .foregroundColor(.red)
                 .font(.system(size: 11))
-        } else if let phone = modelUser.contentBaseUser?.phoneNumber,
-                  Utils
-          .formatNumber(with: "XXX-XXX-XXXX", for: phone)
-          .count != 12 {
-            Text("El teléfono debe tener exactamente 10 dígitos.")
-                .foregroundColor(.red)
-                .font(.system(size: 11))
         }
+        
         
         //----Picker Estado----------------------------------------------------------
         Text("Estado")
@@ -393,7 +387,6 @@ struct Section3: View {
             options: Constants.states
         )
         .padding(.top, 5)
-        .foregroundColor(Color("Secondary"))
       }
 
     }
@@ -444,7 +437,6 @@ struct SectionButton: View{
            })
          )
        }
-       
        VStack {
          Button(action: {
              async {
@@ -462,7 +454,6 @@ struct SectionButton: View{
          }
          .opacity(isFormValid || isPhoneNumberValid ? 1.0 : 0.5)
          .opacity(isFormValid && isPhoneNumberValid ? 1.0 : 0.5)
-         //.opacity(isPhoneNumberValid ? 1.0 : 0.5)
          .disabled(!isPhoneNumberValid)
          .disabled(!isFormValid)
          .alert(isPresented: $showAlert2) {
@@ -540,8 +531,7 @@ struct SectionDelete: View{
     var goLogin: () -> Void
     
     func isPhoneNumberValid() -> Bool {
-        guard let phoneNumber = modelUser
-          .contentBaseUser?.phoneNumber else {
+        guard let phoneNumber = modelUser.contentBaseUser?.phoneNumber else {
             return false
         }
         return phoneNumber.count == 12

--- a/ios/GreenCircle/GreenCircle/Presentation/Views/Profile/EditProfileView.swift
+++ b/ios/GreenCircle/GreenCircle/Presentation/Views/Profile/EditProfileView.swift
@@ -368,7 +368,6 @@ struct Section3: View {
                 .font(.system(size: 11))
         }
         
-        
         //----Picker Estado----------------------------------------------------------
         Text("Estado")
             .padding(.top, 16)
@@ -531,7 +530,8 @@ struct SectionDelete: View{
     var goLogin: () -> Void
     
     func isPhoneNumberValid() -> Bool {
-        guard let phoneNumber = modelUser.contentBaseUser?.phoneNumber else {
+        guard let phoneNumber = modelUser
+          .contentBaseUser?.phoneNumber else {
             return false
         }
         return phoneNumber.count == 12


### PR DESCRIPTION
### Description

Arreglar US de editar perfil ya que en la modificación que alguien hizo a la vista que se mergeo a develop, no funcionaba el field de nombre (no permitía modificarlo) y el botón de guardar siempre estaba en "disabled" hasta que se seleccionara el field de teléfono.

## UI Design (or Program Flow)

### Antes (develop):
https://github.com/salgue441/Net-Zero-Citizens/assets/105307730/a0bb15d6-8ca9-426f-b3e4-05218ff3513f

### Ahora (PR):

https://github.com/salgue441/Net-Zero-Citizens/assets/105307730/551d5c57-d9a2-41e2-a87e-82623d049ae2
